### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Model Context Protocol server for retrieving and managing Chrome browser tabs information. This allows Claude Desktop (or any MCP client) to fetch information about and control currently open Chrome tabs.
 
+<a href="https://glama.ai/mcp/servers/wze1kc6emp"><img width="380" height="200" src="https://glama.ai/mcp/servers/wze1kc6emp/badge" alt="Browser Tabs Server MCP server" /></a>
+
 ## Quick Start (For Users)
 
 To use this tool with Claude Desktop, simply add the following to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json`):


### PR DESCRIPTION
This PR adds a badge for the [MCP Browser Tabs Server](https://glama.ai/mcp/servers/wze1kc6emp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/wze1kc6emp"><img width="380" height="200" src="https://glama.ai/mcp/servers/wze1kc6emp/badge" alt="Browser Tabs Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.